### PR TITLE
fix running bugs....

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ tls-parser = "0.7"
 hwaddr = "0.1.2"
 nom = "5.0.0"
 serde_json = "1.0"
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 httparse = "1.3.0"
 threadpool = "1.0"
 num_cpus = "1.0"

--- a/src/lib/packet_capture.rs
+++ b/src/lib/packet_capture.rs
@@ -131,7 +131,7 @@ impl PacketCapture {
                 if let Some(filter) = filter {
                     cap_handle
                         .filter(&filter)
-                        .expect("Filters invalid, please check the documentation.");;
+                        .expect("Filters invalid, please check the documentation.");
                 }
 
                 while let Ok(packet) = cap_handle.next() {


### PR DESCRIPTION
Solved the following two bugs：
1.
```.expect("Filters invalid, please check the documentation.");;
    |                                                                                     ^ help: remove this semicolon
```
2.
```
warning: unused imports: `Deserialize`, `Serialize`
```